### PR TITLE
Fix SilexFormExtensionto to use getExtendedTypes()

### DIFF
--- a/src/Silex/Provider/Form/SilexFormExtension.php
+++ b/src/Silex/Provider/Form/SilexFormExtension.php
@@ -105,7 +105,9 @@ class SilexFormExtension implements FormExtensionInterface
                 }
                 $extension = $this->app[$extension];
             }
-            $this->typeExtensions[$extension->getExtendedType()][] = $extension;
+            foreach ($extension->getExtendedTypes() as $type) {
+                $this->typeExtensions[$type][] = $extension;
+            }
         }
     }
 


### PR DESCRIPTION
The getExtendedType() API was removed in Symfony 5 and replaced with getExtendedTypes() which returns an iterable of multiple types.